### PR TITLE
Reset version to 1.0.1 for release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy to main server
 
 on:
-  workflow_dispatch:
+  release:
+    types:
+     - published
 
 jobs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools >= 42", "wheel"]
+requires = ["setuptools >= 61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "PASCal"
-version = "2.0.0"
+version = "1.0.1"
 description = "Principal Axis Strain Calculator (PASCal) is a web tool designed to help scientists analyse non-ambient lattice parameter data."
 readme = "README.md"
 keywords = ["materials", "chemistry", "fitting", "strain", "lattice"]
@@ -12,7 +12,7 @@ license = "MIT"
 authors = [ "Matthew Cliffe <matthew.cliffe@nottingham.ac.uk>", ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.8",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
 ]

--- a/src/PASCal/__init__.py
+++ b/src/PASCal/__init__.py
@@ -1,0 +1,5 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("PASCal")
+
+__all__ = ("__version__",)


### PR DESCRIPTION
We should do a release of the "old version" before merging #9. I can't see any info about other releases beyond v1, so this should probably be v1.0.1.

~Additionally, Python 3.8 is going to be out of support fairly soon, so we should update the default Python version of the app.~ saved for future PR