### PR TITLE
Fix form parsing edge-case for critical pressure

### DIFF
--- a/src/PASCal/core.py
+++ b/src/PASCal/core.py
@@ -265,7 +265,7 @@ class PASCalResults:
                 [d[2] if len(d) > 2 else "n/a" for d in sigmas], dtype=object
             )
             self.named_coefficients["PcCoef"] = np.array(
-                [0.0, 0.0, self.options.pc_val]
+                [0.0, 0.0, self.options.pc_val if self.options.pc_val else 0.0]
             )
             self.named_coefficients["CalPress"] = np.zeros(
                 (len(self.volume_fits), len(self.cell_volumes))

--- a/src/PASCal/options.py
+++ b/src/PASCal/options.py
@@ -72,8 +72,13 @@ class Options:
 
         if options.get("data_type"):
             options["data_type"] = PASCalDataType[options["data_type"].upper()]
-        if options.get("pc_val"):
-            options["pc_val"] = float(options["pc_val"])
+        if options.get("pc_val") is not None:
+            if not options.get("pc_val"):
+                options["pc_val"] = None
+            else:
+                options["pc_val"] = float(options["pc_val"])
+        if options.get("pc_val") is None:
+            options["use_pc"] = False
         if options.get("deg_poly_strain"):
             options["deg_poly_strain"] = int(options["deg_poly_strain"])
         if options.get("deg_poly_vol"):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -207,6 +207,33 @@ def test_q_sample_data(
     ), "Volumes table failed"
 
 
+def test_p_no_pc_sample_data(
+    client,
+    sample_p,
+    parser,
+):
+    post_parameters = {
+        "DataType": "Pressure",
+        "EulerianStrain": "True",
+        "FiniteStrain": "True",
+        "DegPolyCap": "",
+        "DegPolyVol": "",
+        "UsePc": "False",
+        "PcVal": "",
+        "data": sample_p,
+    }
+
+    response = client.post("/output", data=post_parameters)
+    assert response.status_code == 200
+
+    html_response = [d for d in response.response]
+    assert len(html_response) == 1
+
+    soup = parser(html_response[0])
+    tables = soup.find_all("table")
+    assert len(tables) == 7
+
+
 def test_parse_options():
     from PASCal.options import Options, PASCalDataType
 
@@ -223,6 +250,24 @@ def test_parse_options():
     assert options.data_type == PASCalDataType.TEMPERATURE
     assert options.use_pc is True
     assert options.pc_val == 0.19
+    assert options.eulerian_strain
+    assert options.deg_poly_strain == 12
+    assert options.deg_poly_vol == 10
+    assert not options.finite_strain
+
+    form_example = {
+        "DataType": "Temperature",
+        "UsePc": "False",
+        "PcVal": "",
+        "EulerianStrain": "True",
+        "DegPolyVol": "10",
+        "DegPolyCap": "12",
+        "FiniteStrain": "False",
+    }
+    options = Options.from_form(form_example)
+    assert options.data_type == PASCalDataType.TEMPERATURE
+    assert options.use_pc is False
+    assert options.pc_val is None
     assert options.eulerian_strain
     assert options.deg_poly_strain == 12
     assert options.deg_poly_vol == 10


### PR DESCRIPTION
This PR fixes an issue where `P_c` and `use_pc` can end up in an inconsistent state. Ideally the UI would not have this redundancy but we should maintain it for now as the fix is easy. 