### PR TITLE
Use Better BibTeX's idea of the best formatting of chemical reference

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -102,7 +102,7 @@
 % ? unused Number of pages ("842")
 
 @article{Goodwin2008a,
-  title = {Large Negative Linear Compressibility of {A}g{$_3$}[{C}o(CN){$_6$}].},
+  title = {Large negative linear compressibility of {{Ag}}{\textsubscript{3}}[{{Co}}({{CN}}){\textsubscript{6}}]}
   author = {Goodwin, Andrew L and Keen, David A and Tucker, Matthew G},
   year = {2008},
   month = dec,


### PR DESCRIPTION
This hopefully fixes JOSS paper build issues.